### PR TITLE
Fix main actor build errors in `Coordinator.swift`

### DIFF
--- a/Sources/NeonPlugin/Coordinator.swift
+++ b/Sources/NeonPlugin/Coordinator.swift
@@ -9,6 +9,7 @@ import SwiftTreeSitter
 import TreeSitter
 import TreeSitterResource
 
+@MainActor
 public class Coordinator {
     private(set) var highlighter: Neon.Highlighter?
     private let language: TreeSitterLanguage


### PR DESCRIPTION
Fix various build errors in `Coordinator.swift` by decorating declaration with `@MainActor`.

![IMG_9738](https://github.com/krzyzanowskim/STTextView-Plugin-Neon/assets/27621026/e9fc19d1-4815-4afa-a897-9438502a0fd0)
