### PR TITLE
Update minimum macOS version to macOS 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "STTextView-Plugin-Neon",
-    platforms: [.macOS(.v12), .iOS(.v16), .macCatalyst(.v16)],
+    platforms: [.macOS(.v14), .iOS(.v16), .macCatalyst(.v16)],
     products: [
         .library(
             name: "STTextView-Plugin-Neon",


### PR DESCRIPTION
So that it aligns with the main package `STTextView`’s and XCode won’t complain.

Otherwise XCode 26.2 won’t compile and shows error like:

```
Build target STPluginNeonAppKit
The package product 'STTextView' requires minimum platform version 14.0 for the macOS platform, but this target supports 12.0
```